### PR TITLE
[WIP] Add query helpers.

### DIFF
--- a/jsonapi-client.gemspec
+++ b/jsonapi-client.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
-  spec.add_development_dependency 'jsonapi-parser', '0.1.1.beta2'
+  spec.add_dependency 'jsonapi-parser', '0.1.1.beta3'
+  spec.add_dependency 'jsonapi-renderer', '0.1.1.beta2'
   spec.add_development_dependency 'rake', '>=0.9'
   spec.add_development_dependency 'rspec', '~>3.4'
 end

--- a/jsonapi-client.gemspec
+++ b/jsonapi-client.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = 'lib'
 
   spec.add_dependency 'jsonapi-parser', '0.1.1.beta3'
-  spec.add_dependency 'jsonapi-renderer', '0.1.1.beta2'
+  spec.add_dependency 'jsonapi-renderer', '0.1.1.beta3'
   spec.add_development_dependency 'rake', '>=0.9'
   spec.add_development_dependency 'rspec', '~>3.4'
 end

--- a/lib/jsonapi/client.rb
+++ b/lib/jsonapi/client.rb
@@ -1,7 +1,25 @@
 require 'jsonapi/parser'
 
 require 'jsonapi/client/document'
-require 'jsonapi/client/resource'
-require 'jsonapi/client/relationship'
-require 'jsonapi/client/link'
-require 'jsonapi/client/error'
+require 'jsonapi/client/request'
+require 'jsonapi/client/response'
+
+module JSONAPI
+  class Client
+    def initialize(base_url: nil, headers: {})
+      @base_url = base_url
+      @headers = {
+        'Content-Type' => 'application/vnd.api+json',
+        'Accept' => 'application/vnd.api+json'
+      }.merge!(headers)
+    end
+
+    def [](endpoint)
+      request(@base_url, endpoint)
+    end
+
+    def request(base_url, endpoint, headers = {})
+      Request.new(base_url, endpoint, @headers.merge(headers))
+    end
+  end
+end

--- a/lib/jsonapi/client.rb
+++ b/lib/jsonapi/client.rb
@@ -9,8 +9,8 @@ module JSONAPI
     def initialize(base_url: nil, headers: {})
       @base_url = base_url
       @headers = {
-        'Content-Type' => 'application/vnd.api+json',
-        'Accept' => 'application/vnd.api+json'
+        :'Content-Type' => 'application/vnd.api+json',
+        :Accept => 'application/vnd.api+json'
       }.merge!(headers)
     end
 
@@ -18,8 +18,11 @@ module JSONAPI
       request(@base_url, endpoint)
     end
 
-    def request(base_url, endpoint, headers = {})
-      Request.new(base_url, endpoint, @headers.merge(headers))
+    def request(base_url, endpoint)
+      req = Request.new(base_url, endpoint)
+      req.headers(@headers) if @headers.any?
+
+      req
     end
   end
 end

--- a/lib/jsonapi/client/document.rb
+++ b/lib/jsonapi/client/document.rb
@@ -1,5 +1,10 @@
+require 'jsonapi/client/resource'
+require 'jsonapi/client/relationship'
+require 'jsonapi/client/link'
+require 'jsonapi/client/error'
+
 module JSONAPI
-  module Client
+  class Client
     class Document
       attr_reader :data, :included, :errors, :links, :meta
 

--- a/lib/jsonapi/client/error.rb
+++ b/lib/jsonapi/client/error.rb
@@ -1,5 +1,5 @@
 module JSONAPI
-  module Client
+  class Client
     class Error
       attr_reader :id, :links, :status, :code, :title, :detail, :source, :meta
 

--- a/lib/jsonapi/client/link.rb
+++ b/lib/jsonapi/client/link.rb
@@ -1,5 +1,5 @@
 module JSONAPI
-  module Client
+  class Client
     class Link
       attr_reader :href, :meta
 

--- a/lib/jsonapi/client/relationship.rb
+++ b/lib/jsonapi/client/relationship.rb
@@ -1,5 +1,5 @@
 module JSONAPI
-  module Client
+  class Client
     class Relationship
       attr_reader :data, :links, :meta
 

--- a/lib/jsonapi/client/request.rb
+++ b/lib/jsonapi/client/request.rb
@@ -1,0 +1,95 @@
+require 'net/http'
+require 'uri'
+
+require 'jsonapi/include_directive'
+
+module JSONAPI
+  class Client
+    class Request
+      METHOD_CLASS = {
+        get: Net::HTTP::Get,
+        post: Net::HTTP::Post,
+        patch: Net::HTTP::Patch,
+        delete: Net::HTTP::Delete
+      }.freeze
+
+      def initialize(base_url, endpoint, headers)
+        @base_url = base_url
+        @endpoint = endpoint
+        @params = []
+        @headers = headers
+      end
+
+      def list
+        request(:get, uri)
+      end
+
+      def request(method, uri, data = {})
+        uri = URI(uri)
+        req = METHOD_CLASS[method].new(uri, @headers)
+        req.body = data if data
+
+        http_res = Net::HTTP.start(uri.host, uri.port) do |http|
+          http.request(req)
+        end
+
+        Response.new(http_res)
+      end
+
+      def find(id)
+        request(:get, uri(id))
+      end
+
+      def create(hash)
+        hash[:type] ||= @endpoint
+        request(:post, uri, hash)
+      end
+
+      def update(id, hash)
+        hash[:type] ||= @endpoint
+        request(:patch, uri(id), hash)
+      end
+
+      def delete(id)
+        request(:delete, uri(id))
+      end
+
+      def headers(hash)
+        @params.merge!(hash)
+        self
+      end
+
+      def params(hash)
+        @params <<
+          if hash.is_a?(String)
+            hash
+          elsif hash.is_a?(Hash)
+            hash.map { |k, v| "#{k}=#{v}" }
+          end
+        self
+      end
+
+      def include(hash)
+        include = JSONAPI::IncludeDirective.new(hash).to_string
+        @params << "include=#{include}"
+        self
+      end
+
+      def fields(hash)
+        hash = { @endpoint => hash } if hash.is_a?(Array)
+        @params += hash.map { |k, v| "fields[#{k}]=#{v.join(',')}" }
+        self
+      end
+
+      private
+
+      def uri(id = nil)
+        uri = "#{@base_url}/#{@endpoint}"
+        uri += "/#{id}" if id
+        uri += "?#{@params.join('&')}" if @params.any?
+
+        uri
+      end
+    end
+  end
+end

--- a/lib/jsonapi/client/request.rb
+++ b/lib/jsonapi/client/request.rb
@@ -117,21 +117,25 @@ module JSONAPI
 
       def request
         uri = URI(full_uri)
-        case @method
-        when :get
-          Net::HTTP::Get.new(uri)
-        when :post
-          Net::HTTP::Post.new(uri).tap do |req|
-            req.body = @data
+        request =
+          case @method
+          when :get
+            Net::HTTP::Get.new(uri)
+          when :post
+            Net::HTTP::Post.new(uri).tap do |req|
+              req.body = @data
+            end
+          when :patch
+            Net::HTTP::Patch.new(uri).tap do |req|
+              req.body = @data
+            end
+          when :delete
+            Net::HTTP::Delete.new(uri)
+          else
+            raise "Unknown request method: #{@method}"
           end
-        when :patch
-          Net::HTTP::Patch.new(uri).tap do |req|
-            req.body = @data
-          end
-        when :delete
-          Net::HTTP::Delete.new(uri)
-        else
-          raise "Unknown request method: #{@method}"
+        @headers.each_with_object(request) do |(k, v), r|
+          r[k] = v
         end
       end
 

--- a/lib/jsonapi/client/request.rb
+++ b/lib/jsonapi/client/request.rb
@@ -14,10 +14,12 @@ module JSONAPI
       end
 
       def call
-        Net::HTTP.start(uri.host, uri.port,
-                        use_ssl: uri.scheme == 'https') do |http|
+        response = Net::HTTP.start(uri.host, uri.port,
+                                   use_ssl: uri.scheme == 'https') do |http|
           http.request request
         end
+
+        Response.new(response)
       end
 
       def list

--- a/lib/jsonapi/client/request.rb
+++ b/lib/jsonapi/client/request.rb
@@ -14,10 +14,11 @@ module JSONAPI
       end
 
       def call
-        response = Net::HTTP.start(uri.host, uri.port,
-                                   use_ssl: uri.scheme == 'https') do |http|
-          http.request request
-        end
+        uri = URI(@base_url)
+        response =
+          Net::HTTP.start(uri.host, use_ssl: uri.scheme == 'https') do |http|
+            http.request request
+          end
 
         Response.new(response)
       end

--- a/lib/jsonapi/client/resource.rb
+++ b/lib/jsonapi/client/resource.rb
@@ -1,5 +1,5 @@
 module JSONAPI
-  module Client
+  class Client
     class Resource
       attr_reader :id, :type, :attributes, :relationships, :links, :meta
 

--- a/lib/jsonapi/client/response.rb
+++ b/lib/jsonapi/client/response.rb
@@ -1,0 +1,25 @@
+require 'jsonapi/client/document'
+
+module JSONAPI
+  class Client
+    class Response
+      def initialize(http_res)
+        @http_res = http_res
+      end
+
+      def status
+        @http_res.code
+      end
+
+      def headers
+        @http_res.to_hash
+      end
+
+      def body
+        return nil if body.nil?
+        json = JSON.parse(@http_res.body)
+        Document.new(json)
+      end
+    end
+  end
+end

--- a/lib/jsonapi/client/response.rb
+++ b/lib/jsonapi/client/response.rb
@@ -16,7 +16,7 @@ module JSONAPI
       end
 
       def body
-        return nil if body.nil?
+        return nil if @http_res.body.nil?
         json = JSON.parse(@http_res.body)
         Document.new(json)
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,13 @@
+require 'jsonapi/client'
+
+describe JSONAPI::Client, '' do
+  it 'works' do
+    client = JSONAPI::Client.new(base_url: 'http://api.example.com')
+
+    client[:users]
+      .include(posts: [:author, comments: [:author]])
+      .fields(posts: [:title, :content], users: [:name, :email])
+      .params(page: 3)
+      .list
+  end
+end


### PR DESCRIPTION
Example:

The following generates a query `http://api.example.com/users/2?include=posts.author,posts.comments.author&fields[posts]=title,content&fields[users]=name,email&page=3` ~~and parses the response (wrapped inside a `JSONAPI::Client::Response` object, that exposes `status`, `headers` and `body`, `body` being a `JSONAPI::Client::Document` instance or `nil`)~~.

``` ruby
  client = JSONAPI::Client.new(base_url: 'http://api.example.com')

  req = client[:users]
    .include(posts: [:author, comments: [:author]])
    .fields(posts: [:title, :content], users: [:name, :email])
    .params(page: 3)
    .find(2)

  req.to_h
# => {
#  :method=>:get, 
#  :uri=>"http://api.example.com/users/2?include=posts.author,posts.comments.author&fields[posts]=title,content&fields[users]=name,email&page=3", 
#  :base_uri=>"http://api.example.com/users/2", 
#  :data=>nil, 
#  :params=>{
#    :include=>"posts.author,posts.comments.author", 
#    :"fields[posts]"=>"title,content", 
#    :"fields[users]"=>"name,email", 
#    :page=>3
#  }, 
#  :headers=>{
#    :"Content-Type"=>"application/vnd.api+json", 
#    :Accept=>"application/vnd.api+json"
#  }
#}
```
